### PR TITLE
feat: Implement server-side video clipping and editor enhancements

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -2,31 +2,29 @@
 
 import * as React from 'react';
 import Image from 'next/image';
-import { storage } from '@/lib/firebase'; // For getDownloadURL
-import { ref as storageRef, getDownloadURL } from 'firebase/storage'; // For getDownloadURL
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { TranscriptViewer } from '@/components/transcript-viewer';
-import type { BrandOptions, Hotspot, Selection, Transcript, Word, ClippingJob } from '@/lib/types'; // Added ClippingJob
+import type { BrandOptions, Hotspot, Selection, Transcript, Word, JobStatus, ClippingJob } from '@/lib/types';
 import { formatTime, cn } from '@/lib/utils';
-import { Scissors, RectangleHorizontal, RectangleVertical, Square, Wand2, RefreshCw, Download } from 'lucide-react'; // Added Download
-import { toast } from '@/hooks/use-toast';
-import { generateVideoBackgroundAction, requestVideoClipAction } from '@/app/actions'; // Added requestVideoClipAction
+import { Scissors, RectangleHorizontal, RectangleVertical, Square, Wand2, RefreshCw, Download } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
+import { generateVideoBackgroundAction, requestVideoClipAction, ActionResult } from '@/app/actions';
 import { Slider } from '@/components/ui/slider';
-import { db } from '@/lib/firebase'; // Added db for Firestore
-import { doc, onSnapshot, Timestamp } from 'firebase/firestore'; // Added Firestore specific imports
-
+import { getStorage, ref as storageRef, getDownloadURL } from 'firebase/storage';
+import { db } from '@/lib/firebase';
+import { doc, onSnapshot } from 'firebase/firestore';
 
 interface EditorProps {
-  videoUrl: string; // This is the blob URL for local playback
-  gcsVideoUri: string | null; // This is the GCS URI for server-side processing
-  transcript: Transcript | null; // Made transcript nullable in previous steps
+  videoUrl: string | null; // Can be a blob URL for local preview
+  gcsVideoUri: string | null; // GCS URI for backend processing
+  transcript: Transcript | null;
   hotspots: Hotspot[] | null;
   brandOptions: BrandOptions;
 }
 
-export function Editor({ videoUrl, transcript, hotspots, brandOptions }: EditorProps) {
+export function Editor({ videoUrl, gcsVideoUri, transcript, hotspots, brandOptions }: EditorProps) {
   const videoRef = React.useRef<HTMLVideoElement>(null);
   const [currentTime, setCurrentTime] = React.useState(0);
   const [selection, setSelection] = React.useState<Selection | null>(null);
@@ -42,12 +40,12 @@ export function Editor({ videoUrl, transcript, hotspots, brandOptions }: EditorP
   const [generativeBg, setGenerativeBg] = React.useState<string | null>(null);
   const [isGeneratingBg, setIsGeneratingBg] = React.useState(false);
 
-  // State for clipping
-  const [currentClippingJobId, setCurrentClippingJobId] = React.useState<string | null>(null);
   const [isClipping, setIsClipping] = React.useState(false);
-  const [clipDownloadUrl, setClipDownloadUrl] = React.useState<string | null>(null);
-  const [clippingStatusMessage, setClippingStatusMessage] = React.useState('');
+  const [clippingStatus, setClippingStatus] = React.useState('');
+  const [currentClippingJobId, setCurrentClippingJobId] = React.useState<string | null>(null);
+  const [finalClipUrl, setFinalClipUrl] = React.useState<string | null>(null);
 
+  const { toast } = useToast();
 
   React.useEffect(() => {
     if (transcript && transcript.words) {
@@ -58,10 +56,107 @@ export function Editor({ videoUrl, transcript, hotspots, brandOptions }: EditorP
   }, [transcript]);
   
   React.useEffect(() => {
-    // Reset zoom and pan when aspect ratio changes
     setZoom(1);
     setPan({ x: 0, y: 0 });
   }, [aspectRatio]);
+
+  // Temporary useEffect to set a default selection for testing clipping
+  React.useEffect(() => {
+    const videoElement = videoRef.current;
+    if (videoElement && gcsVideoUri && !selection && !transcript) {
+      const setTestSelection = () => {
+        if (videoElement.duration && isFinite(videoElement.duration) && videoElement.duration > 0) {
+          let defaultStartTime = 1;
+          let defaultEndTime = Math.min(5, videoElement.duration - 0.1); // Ensure end time is within duration
+
+          if (videoElement.duration <= 1.1) {
+            defaultStartTime = 0;
+            defaultEndTime = videoElement.duration;
+          } else if (videoElement.duration <= 5) {
+            defaultStartTime = 0;
+            defaultEndTime = videoElement.duration;
+          }
+
+          if (defaultEndTime > defaultStartTime) {
+            console.log(`[EDITOR.TSX] Setting default selection for clipping test: ${defaultStartTime.toFixed(2)}s to ${defaultEndTime.toFixed(2)}s`);
+            setSelection({ start: defaultStartTime, end: defaultEndTime });
+            toast({ title: "Test Selection Set", description: `Default selection: ${defaultStartTime.toFixed(1)}s to ${defaultEndTime.toFixed(1)}s. Adjust as needed.`, duration: 4000 });
+          } else {
+            console.warn("[EDITOR.TSX] Video too short or default times invalid, not setting default selection.");
+          }
+        } else {
+          console.log("[EDITOR.TSX] Video duration not yet available or invalid for default selection.");
+        }
+      };
+
+      if (videoElement.readyState >= HTMLMediaElement.HAVE_METADATA) {
+        setTestSelection();
+      } else {
+        const handleMetadataLoaded = () => {
+          setTestSelection();
+          videoElement.removeEventListener('loadedmetadata', handleMetadataLoaded);
+        };
+        videoElement.addEventListener('loadedmetadata', handleMetadataLoaded);
+        return () => {
+          videoElement.removeEventListener('loadedmetadata', handleMetadataLoaded);
+        };
+      }
+    }
+  }, [gcsVideoUri, selection, transcript, videoUrl, toast]);
+
+
+  // Firestore listener for clipping jobs
+  React.useEffect(() => {
+    if (!currentClippingJobId) {
+      setFinalClipUrl(null); // Clear any previous clip URL
+      return;
+    }
+
+    setIsClipping(true);
+    setClippingStatus('Clipping job started. Waiting for updates...');
+    setFinalClipUrl(null);
+
+    const unsubscribe = onSnapshot(doc(db, "clippingJobs", currentClippingJobId), async (jobDoc) => {
+      console.log(`[EDITOR.TSX] Clipping job update for ${currentClippingJobId}:`, jobDoc.data());
+      if (jobDoc.exists()) {
+        const jobData = jobDoc.data() as ClippingJob;
+        setClippingStatus(`Clip status: ${jobData.status.toLowerCase()}...`);
+
+        if (jobData.status === 'COMPLETED') {
+          if (jobData.clippedVideoGcsUri) {
+            try {
+              const fStorage = getStorage();
+              const clipRef = storageRef(fStorage, jobData.clippedVideoGcsUri); // Pass GCS URI directly
+              const downloadUrl = await getDownloadURL(clipRef);
+              setFinalClipUrl(downloadUrl);
+              toast({ title: "Clip Ready!", description: "Your video clip has been processed." });
+              console.log(`[EDITOR.TSX] Clip ready. Download URL: ${downloadUrl}`);
+            } catch (error) {
+              console.error("[EDITOR.TSX] Error getting download URL:", error);
+              toast({ variant: "destructive", title: "Error", description: "Could not get clip download URL." });
+              setFinalClipUrl(null);
+            }
+          } else {
+            toast({ variant: "destructive", title: "Error", description: "Clipping completed but no video URL found." });
+            setFinalClipUrl(null);
+          }
+          setIsClipping(false);
+          setCurrentClippingJobId(null); // Reset for next job
+        } else if (jobData.status === 'FAILED') {
+          toast({ variant: "destructive", title: "Clipping Failed", description: jobData.error || "An unknown error occurred during clipping." });
+          setIsClipping(false);
+          setCurrentClippingJobId(null);
+          setFinalClipUrl(null);
+        }
+      } else {
+        console.warn(`[EDITOR.TSX] Clipping job document ${currentClippingJobId} not found.`);
+        // Don't reset isClipping here, might be a delay
+      }
+    });
+
+    return () => unsubscribe();
+  }, [currentClippingJobId, toast]);
+
 
   const handleTimeUpdate = () => {
     if (videoRef.current) {
@@ -72,128 +167,53 @@ export function Editor({ videoUrl, transcript, hotspots, brandOptions }: EditorP
   const handleSeek = (time: number) => {
     if (videoRef.current) {
       videoRef.current.currentTime = time;
-      videoRef.current.play();
+      if (videoRef.current.paused) {
+        // videoRef.current.play(); // Optional: auto-play on seek
+      }
     }
   };
-  
-  // Firestore listener for clipping job
-  React.useEffect(() => {
-    if (!currentClippingJobId) return;
-
-    setClippingStatusMessage('Clipping job requested. Waiting for updates...');
-    const unsubscribe = onSnapshot(doc(db, "clippingJobs", currentClippingJobId), async (jobDoc) => {
-      if (jobDoc.exists()) {
-        const jobData = jobDoc.data() as Omit<ClippingJob, 'id'> & { createdAt: Timestamp, updatedAt: Timestamp };
-        setClippingStatusMessage(`Clip status: ${jobData.status.toLowerCase()}...`);
-
-        switch (jobData.status) {
-          case 'PROCESSING':
-            setIsClipping(true);
-            setClippingStatusMessage('Your clip is being processed...');
-            break;
-          case 'COMPLETED':
-            if (jobData.clippedVideoGcsUri) {
-              try {
-                const downloadUrl = await getDownloadURL(storageRef(storage, jobData.clippedVideoGcsUri));
-                setClipDownloadUrl(downloadUrl);
-                toast({
-                  title: "Clip Ready!",
-                  description: "Your video clip is ready for download.",
-                });
-                setClippingStatusMessage('Clip ready for download!');
-              } catch (error) {
-                console.error("Error getting download URL:", error);
-                toast({ variant: "destructive", title: "Error", description: "Could not get clip download URL." });
-                setClippingStatusMessage('Error: Could not get download URL.');
-              }
-            } else {
-              toast({ variant: "destructive", title: "Error", description: "Clipping completed but no URI found." });
-              setClippingStatusMessage('Error: Clip URI missing.');
-            }
-            setIsClipping(false);
-            setCurrentClippingJobId(null); // Clear job ID
-            unsubscribe();
-            break;
-          case 'FAILED':
-            console.error('Clipping job failed:', jobData.error);
-            toast({
-              variant: "destructive",
-              title: "Clipping Failed",
-              description: jobData.error || "The video clip could not be generated.",
-            });
-            setClippingStatusMessage(`Failed: ${jobData.error || "Unknown error"}`);
-            setIsClipping(false);
-            setCurrentClippingJobId(null); // Clear job ID
-            unsubscribe();
-            break;
-          case 'PENDING':
-            setIsClipping(true);
-            setClippingStatusMessage('Clip job is pending...');
-            break;
-        }
-      } else {
-        console.warn("Clipping job document not found for ID:", currentClippingJobId);
-        // Potentially handle this, though it shouldn't happen if created correctly
-      }
-    }, (error) => {
-      console.error("Error listening to clipping job updates:", error);
-      toast({
-        variant: "destructive",
-        title: "Connection Error",
-        description: "Could not listen for clipping updates.",
-      });
-      setIsClipping(false);
-      setCurrentClippingJobId(null);
-      setClippingStatusMessage('Error: Connection failed.');
-    });
-
-    return () => unsubscribe();
-  }, [currentClippingJobId, toast]);
 
   const handleCreateClip = async () => {
-    if (!selection || !gcsVideoUri) {
-      toast({
-        variant: "destructive",
-        title: "Cannot Create Clip",
-        description: !gcsVideoUri ? "Video GCS URI is missing." : "No portion of the video is selected.",
-      });
+    if (!selection) {
+      toast({ title: "No Selection", description: "Please select a portion of the video to clip.", variant: "destructive" });
       return;
     }
-    if (isClipping) return;
+    if (!gcsVideoUri) {
+      toast({ title: "Video Not Uploaded", description: "Source video GCS URI is missing.", variant: "destructive" });
+      return;
+    }
+    if (isClipping) {
+        toast({ title: "Processing...", description: "A clipping job is already in progress."});
+        return;
+    }
 
+    console.log(`[EDITOR.TSX] Requesting clip for ${gcsVideoUri} from ${selection.start}s to ${selection.end}s`);
     setIsClipping(true);
-    setClipDownloadUrl(null); // Reset previous download URL
-    setClippingStatusMessage('Requesting video clip...');
-    toast({
-      title: "Requesting Clip...",
-      description: "Your video clip request is being sent.",
-    });
+    setClippingStatus('Requesting video clip...');
+    setFinalClipUrl(null);
 
     try {
       const result = await requestVideoClipAction({
         gcsUri: gcsVideoUri,
         startTime: selection.start,
         endTime: selection.end,
-        // outputFormat: 'mp4', // Default is mp4 in action
-      });
+        // outputFormat: 'mp4' // Default is mp4 in action
+      }) as ActionResult;
 
       if (result.success && result.jobId) {
         setCurrentClippingJobId(result.jobId);
-        // useEffect listener will pick up from here
+        toast({ title: "Clipping Job Started", description: `Job ID: ${result.jobId}. Waiting for completion...` });
       } else {
         throw new Error(result.error || "Failed to start clipping job.");
       }
     } catch (error: any) {
-      console.error("Failed to request video clip:", error);
-      toast({
-        variant: "destructive",
-        title: "Clipping Request Failed",
-        description: error.message || "An unknown error occurred.",
-      });
+      console.error("[EDITOR.TSX] Error calling requestVideoClipAction:", error);
+      toast({ variant: "destructive", title: "Clipping Request Failed", description: error.message });
       setIsClipping(false);
-      setClippingStatusMessage(`Error: ${error.message}`);
+      setClippingStatus('Clipping request failed.');
     }
   };
+
 
   const handlePanMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     if (zoom <= 1 || aspectRatio === 'original') return;
@@ -221,50 +241,55 @@ export function Editor({ videoUrl, transcript, hotspots, brandOptions }: EditorP
 
   const handleGenerateBackground = async () => {
     if (!videoRef.current || isGeneratingBg) return;
-
     setIsGeneratingBg(true);
-    toast({
-        title: "Generating background...",
-        description: "AI is creating a custom background. This might take a moment.",
-    });
-
+    toast({ title: "Generating background..." });
     try {
+        const videoElement = videoRef.current;
+        await new Promise<void>((resolve, reject) => {
+            if (videoElement.readyState >= HTMLMediaElement.HAVE_METADATA) {
+                resolve();
+            } else {
+                videoElement.onloadedmetadata = () => resolve();
+                videoElement.onerror = () => reject(new Error("Video metadata failed to load"));
+            }
+        });
+
+        if (!videoElement.videoWidth || !videoElement.videoHeight) {
+          throw new Error("Video dimensions are not available.");
+        }
+
         const canvas = document.createElement('canvas');
-        canvas.width = videoRef.current.videoWidth;
-        canvas.height = videoRef.current.videoHeight;
+        canvas.width = videoElement.videoWidth;
+        canvas.height = videoElement.videoHeight;
         const ctx = canvas.getContext('2d');
         if (!ctx) throw new Error('Could not get canvas context');
         
-        // Seek to the middle of the video for a representative frame
-        videoRef.current.currentTime = videoRef.current.duration / 2;
+        if (videoElement.duration && isFinite(videoElement.duration) && videoElement.duration > 0) {
+            videoElement.currentTime = videoElement.duration / 2;
+        } else {
+            videoElement.currentTime = 0;
+        }
         
-        // Wait for the frame to be ready
-        await new Promise(resolve => {
-          videoRef.current!.onseeked = () => resolve(true);
+        await new Promise<void>((resolve, reject) => {
+            videoElement.onseeked = () => resolve();
+            videoElement.onerror = () => reject(new Error("Video seek failed"));
         });
 
-        ctx.drawImage(videoRef.current, 0, 0, canvas.width, canvas.height);
+        ctx.drawImage(videoElement, 0, 0, canvas.width, canvas.height);
         const frameDataUri = canvas.toDataURL('image/jpeg');
 
-        const result = await generateVideoBackgroundAction({ frameDataUri });
+        const result = await generateVideoBackgroundAction({ frameDataUri }) as ActionResult<{ backgroundDataUri: string }>;
 
-        if (result.success && result.data) {
+        if (result.success && result.data && result.data.backgroundDataUri) {
             setGenerativeBg(result.data.backgroundDataUri);
-            toast({
-                title: "AI Background Generated!",
-                description: "Your new background has been applied.",
-            });
+            toast({ title: "AI Background Generated!" });
         } else {
-            throw new Error(result.error || 'Failed to generate background.');
+            throw new Error(result.error || 'Failed to generate background or missing URI.');
         }
-    } catch (error) {
-        console.error('Generative fill failed:', error);
-        toast({
-            variant: "destructive",
-            title: "Oh no! Background generation failed.",
-            description: error instanceof Error ? error.message : "An unknown error occurred.",
-        });
-        setFillMode('black');
+    } catch (error: any) {
+        console.error('[EDITOR.TSX] Generative fill failed:', error);
+        toast({ variant: "destructive", title: "Background Generation Failed", description: error.message });
+        setFillMode('black'); // Revert to black on failure
     } finally {
         setIsGeneratingBg(false);
     }
@@ -279,7 +304,7 @@ export function Editor({ videoUrl, transcript, hotspots, brandOptions }: EditorP
             <div className="flex flex-col sm:flex-row justify-center items-center gap-4 sm:gap-6 mb-2">
                 <div className="flex items-center gap-2">
                     <span className="text-sm text-muted-foreground font-medium">Aspect:</span>
-                    <ToggleGroup type="single" variant="outline" size="sm" value={aspectRatio} onValueChange={(v: typeof aspectRatio) => v && setAspectRatio(v)} >
+                    <ToggleGroup type="single" variant="outline" size="sm" value={aspectRatio} onValueChange={(v: any) => v && setAspectRatio(v)} >
                         <ToggleGroupItem value="original" aria-label="Original"><RectangleHorizontal className="h-5 w-5" /></ToggleGroupItem>
                         <ToggleGroupItem value="portrait" aria-label="Portrait"><RectangleVertical className="h-5 w-5" /></ToggleGroupItem>
                         <ToggleGroupItem value="square" aria-label="Square"><Square className="h-5 w-5" /></ToggleGroupItem>
@@ -287,7 +312,7 @@ export function Editor({ videoUrl, transcript, hotspots, brandOptions }: EditorP
                 </div>
                  <div className="flex items-center gap-2">
                     <span className="text-sm text-muted-foreground font-medium">Fill:</span>
-                    <ToggleGroup type="single" variant="outline" size="sm" value={fillMode} onValueChange={(v: typeof fillMode) => v && setFillMode(v)} disabled={aspectRatio === 'original'}>
+                    <ToggleGroup type="single" variant="outline" size="sm" value={fillMode} onValueChange={(v: any) => v && setFillMode(v)} disabled={aspectRatio === 'original'}>
                         <ToggleGroupItem value="black" aria-label="Black background">Black</ToggleGroupItem>
                         <ToggleGroupItem value="blur" aria-label="Blurred background">Blur</ToggleGroupItem>
                         <ToggleGroupItem value="generative" aria-label="Generative AI background">AI</ToggleGroupItem>
@@ -322,7 +347,7 @@ export function Editor({ videoUrl, transcript, hotspots, brandOptions }: EditorP
                     )}
                     style={{ cursor: zoom > 1 && aspectRatio !== 'original' ? (isPanning ? 'grabbing' : 'grab') : 'default' }}
                 >
-                    {aspectRatio !== 'original' && fillMode === 'blur' && (
+                    {aspectRatio !== 'original' && fillMode === 'blur' && videoUrl && (
                         <video key={`bg-blur-${videoUrl}`} src={videoUrl} className="absolute inset-0 w-full h-full object-cover blur-2xl scale-110 opacity-50" muted loop autoPlay playsInline />
                     )}
                     {aspectRatio !== 'original' && fillMode === 'generative' && generativeBg && (
@@ -337,15 +362,18 @@ export function Editor({ videoUrl, transcript, hotspots, brandOptions }: EditorP
                           className="w-full h-full transition-transform duration-100 ease-linear"
                           style={{ transform: `scale(${zoom}) translate(${pan.x}px, ${pan.y}px)` }}
                       >
-                          <video
-                              key={`main-${videoUrl}`}
-                              ref={videoRef}
-                              src={videoUrl}
-                              className="w-full h-full object-contain"
-                              onTimeUpdate={handleTimeUpdate}
-                              onClick={() => videoRef.current?.paused ? videoRef.current?.play() : videoRef.current?.pause()}
-                              playsInline
-                          />
+                          {videoUrl && (
+                            <video
+                                key={`main-${videoUrl}`}
+                                ref={videoRef}
+                                src={videoUrl}
+                                className="w-full h-full object-contain"
+                                onTimeUpdate={handleTimeUpdate}
+                                onClick={() => videoRef.current?.paused ? videoRef.current?.play() : videoRef.current?.pause()}
+                                playsInline
+                                controls
+                            />
+                          )}
                       </div>
                     </div>
                     
@@ -362,7 +390,7 @@ export function Editor({ videoUrl, transcript, hotspots, brandOptions }: EditorP
             <div className="text-sm">
                 <p className="font-semibold font-headline">Selected Clip</p>
                 <p className="text-muted-foreground">
-                    {selection ? `${formatTime(selection.start)} - ${formatTime(selection.end)}` : 'No selection'}
+                    {selection ? `${formatTime(selection.start)} - ${formatTime(selection.end)}` : 'No selection yet'}
                 </p>
             </div>
             <div className="flex items-center gap-4">
@@ -370,25 +398,20 @@ export function Editor({ videoUrl, transcript, hotspots, brandOptions }: EditorP
                     <p className="font-semibold font-headline">Duration</p>
                     <p className="font-mono text-lg font-medium">{formatTime(selectionDuration)}</p>
                 </div>
-                {clipDownloadUrl ? (
-                  <Button asChild size="lg">
-                    <a href={clipDownloadUrl} download target="_blank" rel="noopener noreferrer">
-                      <Download className="mr-2 h-5 w-5" />
-                      Download Clip
+                <Button onClick={handleCreateClip} disabled={!selection || isClipping || !gcsVideoUri} size="lg">
+                  {isClipping ? <RefreshCw className="mr-2 h-5 w-5 animate-spin" /> : <Scissors className="mr-2 h-5 w-5"/>}
+                  {isClipping ? clippingStatus || 'Clipping...' : 'Create Clip'}
+                </Button>
+                {finalClipUrl && (
+                  <Button asChild variant="outline" size="lg">
+                    <a href={finalClipUrl} download target="_blank" rel="noopener noreferrer">
+                      <Download className="mr-2 h-5 w-5" /> Download Clip
                     </a>
-                  </Button>
-                ) : (
-                  <Button onClick={handleCreateClip} disabled={!selection || isClipping || !gcsVideoUri} size="lg">
-                    <Scissors className="mr-2 h-5 w-5"/>
-                    {isClipping ? 'Clipping...' : 'Create Clip'}
                   </Button>
                 )}
             </div>
           </CardContent>
         </Card>
-        {clippingStatusMessage && (
-          <p className="text-sm text-muted-foreground text-center mt-2">{clippingStatusMessage}</p>
-        )}
       </div>
 
       <div className="lg:col-span-1 h-full">


### PR DESCRIPTION
- Adds server-side video clipping functionality using a new GCF (videoClipperWorker) triggered by a Next.js server action (requestVideoClipAction).
- The GCF uses FFmpeg to cut video segments based on start/end times.
- Firestore (`clippingJobs` collection) is used to track job status.
- Client-side logic in `editor.tsx` handles clip requests, monitors job status, and provides a download link.
- Includes default selection logic in `editor.tsx` to enable clipping tests without a transcript.
- Resolves various TypeScript errors and ensures necessary props and types are correctly handled across `actions.ts`, `page.tsx`, and `editor.tsx`.
- Confirmed GCS upload, editor display, aspect ratio, zoom/pan, and AI background generation are working.
- Decoupled automatic transcription from upload; transcription will be manually triggered later.